### PR TITLE
Made object factory able to use dependency injection for creating files.

### DIFF
--- a/SharpSerializer.AutofacInstanceCreator.Tests/AutofacInstanceCreatorTests.cs
+++ b/SharpSerializer.AutofacInstanceCreator.Tests/AutofacInstanceCreatorTests.cs
@@ -1,0 +1,76 @@
+﻿namespace SharpSerializer.AutofacInstanceCreator.Tests
+{
+  using System.IO;
+  using System.Text;
+  using Autofac;
+  using Microsoft.VisualStudio.TestTools.UnitTesting;
+  using Polenter.Serialization;
+
+  [TestClass]
+  public class AutofacInstanceCreatorTests
+  {
+    [TestMethod]
+    public void CreateInstanceWithAutofacCreatesRegisteredType()
+    {
+      ContainerBuilder builder = new ContainerBuilder();
+      builder.RegisterType<TestObject>().As<ITestObject>();
+      builder.RegisterType<TestChild>().As<ITestChild>();
+      IContainer container = builder.Build();
+
+      string serializeResult = this.Serialize(container, new TestObject());
+
+      ITestObject deserializeResult = this.Deserialize(container, serializeResult);
+      Assert.IsNotNull(deserializeResult);
+
+      Assert.IsNotNull(deserializeResult.TestChild);
+    }
+
+    [TestMethod]
+    public void CreateInstanceWithAutofacUsesDefaultCreatorWhenNotKnown()
+    {
+      ContainerBuilder builder = new ContainerBuilder();
+      IContainer container = builder.Build();
+
+      string serializeResult = this.Serialize(container, new TestObject());
+
+      ITestObject deserializeResult = this.Deserialize(container, serializeResult);
+      Assert.IsNotNull(deserializeResult);
+
+      Assert.IsNull(deserializeResult.TestChild);
+    }
+
+    private string Serialize(IContainer container, ITestObject testObject)
+    {
+      SharpSerializer serializer = this.CreateSerializer(container);
+      string result;
+      using (MemoryStream stream = new MemoryStream())
+      {
+        serializer.Serialize(testObject, stream);
+        result = Encoding.UTF8.GetString(stream.ToArray());
+      }
+
+      return result;
+    }
+
+    private SharpSerializer CreateSerializer(IContainer container)
+    {
+      SharpSerializerXmlSettings settings = new SharpSerializerXmlSettings();
+      settings.InstanceCreator = new AutofacInstanceCreator(container);
+
+      return new SharpSerializer(settings);
+    }
+
+    private ITestObject Deserialize(IContainer container, string serializeResult)
+    {
+      SharpSerializer serializer = this.CreateSerializer(container);
+      object result;
+      using (MemoryStream stream = new MemoryStream(Encoding.UTF8.GetBytes(serializeResult)))
+      {
+        result = serializer.Deserialize(stream);
+      }
+
+      return result as ITestObject;
+    }
+
+  }
+}

--- a/SharpSerializer.AutofacInstanceCreator.Tests/AutofacInstanceCreatorTests.cs
+++ b/SharpSerializer.AutofacInstanceCreator.Tests/AutofacInstanceCreatorTests.cs
@@ -13,8 +13,8 @@
     public void CreateInstanceWithAutofacCreatesRegisteredType()
     {
       ContainerBuilder builder = new ContainerBuilder();
-      builder.RegisterType<TestObject>().As<ITestObject>();
-      builder.RegisterType<TestChild>().As<ITestChild>();
+      builder.RegisterType<TestObject>().AsImplementedInterfaces();
+      builder.RegisterType<TestChild>().AsImplementedInterfaces();
       IContainer container = builder.Build();
 
       string serializeResult = this.Serialize(container, new TestObject());

--- a/SharpSerializer.AutofacInstanceCreator.Tests/IMyInterface.cs
+++ b/SharpSerializer.AutofacInstanceCreator.Tests/IMyInterface.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SharpSerializer.AutofacInstanceCreator.Tests
+{
+  public interface IMyInterface
+  {
+  }
+}

--- a/SharpSerializer.AutofacInstanceCreator.Tests/ITestChild.cs
+++ b/SharpSerializer.AutofacInstanceCreator.Tests/ITestChild.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SharpSerializer.AutofacInstanceCreator.Tests
+{
+  public interface ITestChild
+  {
+  }
+}

--- a/SharpSerializer.AutofacInstanceCreator.Tests/ITestObject.cs
+++ b/SharpSerializer.AutofacInstanceCreator.Tests/ITestObject.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SharpSerializer.AutofacInstanceCreator.Tests
+{
+  public interface ITestObject
+  {
+    ITestChild TestChild { get; set; }
+  }
+}

--- a/SharpSerializer.AutofacInstanceCreator.Tests/Properties/AssemblyInfo.cs
+++ b/SharpSerializer.AutofacInstanceCreator.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,20 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("SharpSerializer.AutofacInstanceCreator.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("SharpSerializer.AutofacInstanceCreator.Tests")]
+[assembly: AssemblyCopyright("Copyright ©  2018")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+[assembly: ComVisible(false)]
+
+[assembly: Guid("c480c73c-271a-4127-b13a-ab89942fcda8")]
+
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/SharpSerializer.AutofacInstanceCreator.Tests/SharpSerializer.AutofacInstanceCreator.Tests.csproj
+++ b/SharpSerializer.AutofacInstanceCreator.Tests/SharpSerializer.AutofacInstanceCreator.Tests.csproj
@@ -1,0 +1,92 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{C480C73C-271A-4127-B13A-AB89942FCDA8}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>SharpSerializer.AutofacInstanceCreator.Tests</RootNamespace>
+    <AssemblyName>SharpSerializer.AutofacInstanceCreator.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Autofac, Version=4.6.2.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
+      <HintPath>..\packages\Autofac.4.6.2\lib\net45\Autofac.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MSTest.TestFramework.1.2.0\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MSTest.TestFramework.1.2.0\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.IO.Compression.FileSystem" />
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="AutofacInstanceCreatorTests.cs" />
+    <Compile Include="ITestChild.cs" />
+    <Compile Include="ITestObject.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TestChild.cs" />
+    <Compile Include="TestObject.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\SharpSerializer.AutofacInstanceCreator\SharpSerializer.AutofacInstanceCreator.csproj">
+      <Project>{9b0de06d-36dc-48ba-b7b6-c5450666c6e7}</Project>
+      <Name>SharpSerializer.AutofacInstanceCreator</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\SharpSerializer\SharpSerializer.csproj">
+      <Project>{d9b06b37-64a0-45c5-a6b7-5af26652c8f0}</Project>
+      <Name>SharpSerializer</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.props'))" />
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.targets'))" />
+  </Target>
+  <Import Project="..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.targets')" />
+</Project>

--- a/SharpSerializer.AutofacInstanceCreator.Tests/SharpSerializer.AutofacInstanceCreator.Tests.csproj
+++ b/SharpSerializer.AutofacInstanceCreator.Tests/SharpSerializer.AutofacInstanceCreator.Tests.csproj
@@ -61,6 +61,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AutofacInstanceCreatorTests.cs" />
+    <Compile Include="IMyInterface.cs" />
     <Compile Include="ITestChild.cs" />
     <Compile Include="ITestObject.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/SharpSerializer.AutofacInstanceCreator.Tests/SharpSerializer.AutofacInstanceCreator.Tests.csproj
+++ b/SharpSerializer.AutofacInstanceCreator.Tests/SharpSerializer.AutofacInstanceCreator.Tests.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SharpSerializer.AutofacInstanceCreator.Tests</RootNamespace>
     <AssemblyName>SharpSerializer.AutofacInstanceCreator.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
@@ -19,6 +19,7 @@
     <TestProjectType>UnitTest</TestProjectType>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/SharpSerializer.AutofacInstanceCreator.Tests/TestChild.cs
+++ b/SharpSerializer.AutofacInstanceCreator.Tests/TestChild.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SharpSerializer.AutofacInstanceCreator.Tests
+{
+  public class TestChild : ITestChild
+  {
+  }
+}

--- a/SharpSerializer.AutofacInstanceCreator.Tests/TestObject.cs
+++ b/SharpSerializer.AutofacInstanceCreator.Tests/TestObject.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SharpSerializer.AutofacInstanceCreator.Tests
+{
+  using Polenter.Serialization;
+
+  public class TestObject : ITestObject
+  {
+    public TestObject()
+    {
+
+    }
+
+    public TestObject(ITestChild testChild)
+    {
+      this.TestChild = testChild;
+    }
+
+    [ExcludeFromSerialization]
+    public ITestChild TestChild { get; set; }
+  }
+}

--- a/SharpSerializer.AutofacInstanceCreator.Tests/TestObject.cs
+++ b/SharpSerializer.AutofacInstanceCreator.Tests/TestObject.cs
@@ -8,7 +8,7 @@ namespace SharpSerializer.AutofacInstanceCreator.Tests
 {
   using Polenter.Serialization;
 
-  public class TestObject : ITestObject
+  public class TestObject : ITestObject, IMyInterface
   {
     public TestObject()
     {

--- a/SharpSerializer.AutofacInstanceCreator.Tests/packages.config
+++ b/SharpSerializer.AutofacInstanceCreator.Tests/packages.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Autofac" version="4.6.2" targetFramework="net461" />
+  <package id="MSTest.TestAdapter" version="1.2.0" targetFramework="net461" />
+  <package id="MSTest.TestFramework" version="1.2.0" targetFramework="net461" />
+</packages>

--- a/SharpSerializer.AutofacInstanceCreator/AutofacInstanceCreator.cs
+++ b/SharpSerializer.AutofacInstanceCreator/AutofacInstanceCreator.cs
@@ -1,12 +1,17 @@
 ﻿namespace SharpSerializer.AutofacInstanceCreator
 {
     using System;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
+    using System.Runtime.Caching;
     using Autofac;
     using Polenter.Serialization.Core;
     public class AutofacInstanceCreator : IInstanceCreator
     {
-        private IContainer Container { get; set; }
+        private MemoryCache Cache { get; set; }
+
+        private ILifetimeScope Container { get; set; }
 
         private IInstanceCreator DefaultInstanceCreator { get; set; }
 
@@ -16,11 +21,19 @@
         /// <value><c>true</c> if concrete types should be translated to interfaces; otherwise, <c>false</c>.</value>
         public bool TranslateConcreteTypes { get; set; }
 
-        public AutofacInstanceCreator(IContainer container)
+        /// <summary>
+        /// Gets or sets the interface prefix that will be used when attempting to lookup the interface.  Defaults to "I"
+        /// </summary>
+        /// <value>The interface prefix.</value>
+        public string InterfacePrefix { get; set; }
+
+        public AutofacInstanceCreator(ILifetimeScope container)
         {
             this.Container = container;
             this.TranslateConcreteTypes = true;
             this.DefaultInstanceCreator = new DefaultInstanceCreator();
+            this.InterfacePrefix = "I";
+            this.Cache = new MemoryCache("AutofacInstanceCreator");
         }
 
         /// <summary>
@@ -28,7 +41,10 @@
         /// </summary>
         /// <param name="type">The type.</param>
         /// <returns>System.Object.</returns>
-        /// <remarks>By default, Activator.CreateInstance will be used to create the instance.  Change the setting InstanceCreator to supply a different instance creator.</remarks>
+        /// <remarks>By default, Activator.CreateInstance will be used to create the instance.  Change the setting InstanceCreator to supply a different instance creator.
+        /// With the sharp serializer, the concrete types are going to typically be output as part of the serialization.  You may want to register those types AsSelf, and then
+        /// the TranslateConcreteTypes call will never be made.
+        /// </remarks>
         public object CreateInstance(Type type)
         {
             object result;
@@ -61,25 +77,56 @@
 
         private Type TranslateToInterface(Type concreteType)
         {
-          Type result = null;
-          var registration = this.Container.ComponentRegistry.Registrations.FirstOrDefault(r => r.Activator.LimitType == concreteType);
-          if (registration != null)
+          Type result = (Type)this.Cache.Get(concreteType.FullName);
+
+          if (result == null)
           {
-            if (registration.Services.Any())
+            var registration = this.Container.ComponentRegistry.Registrations.FirstOrDefault(r => r.Activator.LimitType == concreteType);
+            if (registration != null)
             {
-              string typeName = registration.Services.Last().Description;
-              foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+              if (registration.Services.Any())
               {
-                result = assembly.GetType(typeName);
+                Type registrationType = registration.Activator.LimitType;
+                string inferredInterfaceName = this.InterfacePrefix + registrationType.Name;
+
+                // exact by convention match is preferred
+                foreach (var service in registration.Services)
+                {
+                  string serviceTypeName = service.Description;
+                  Type serviceType = this.GetServiceType(serviceTypeName);
+                  if (serviceType != null && serviceType.Name == inferredInterfaceName)
+                  {
+                    result = serviceType;
+                    break;
+                  }
+                }
+
                 if (result != null)
                 {
-                  break;
+                  this.Cache.Add(concreteType.FullName, result, new CacheItemPolicy() { SlidingExpiration = TimeSpan.FromHours(1) });
                 }
+
+                // no match?  We'll just return null and default back to just a create of the entity directly.  We could attempt a match based on nearest namespace, but it'd be wrong a lot.
               }
             }
           }
 
           return result;
         }
+
+      private Type GetServiceType(string serviceTypeName)
+      {
+        Type result = null;
+        foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+        {
+          result = assembly.GetType(serviceTypeName);
+          if (result != null)
+          {
+            break;
+          }
+        }
+
+        return result;
+      }
   }
 }

--- a/SharpSerializer.AutofacInstanceCreator/AutofacInstanceCreator.cs
+++ b/SharpSerializer.AutofacInstanceCreator/AutofacInstanceCreator.cs
@@ -1,0 +1,85 @@
+﻿namespace SharpSerializer.AutofacInstanceCreator
+{
+    using System;
+    using System.Linq;
+    using Autofac;
+    using Polenter.Serialization.Core;
+    public class AutofacInstanceCreator : IInstanceCreator
+    {
+        private IContainer Container { get; set; }
+
+        private IInstanceCreator DefaultInstanceCreator { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether concrete types should be translated to interfaces.  Defaults to true.
+        /// </summary>
+        /// <value><c>true</c> if concrete types should be translated to interfaces; otherwise, <c>false</c>.</value>
+        public bool TranslateConcreteTypes { get; set; }
+
+        public AutofacInstanceCreator(IContainer container)
+        {
+            this.Container = container;
+            this.TranslateConcreteTypes = true;
+            this.DefaultInstanceCreator = new DefaultInstanceCreator();
+        }
+
+        /// <summary>
+        /// Creates an instance of the object of the specific type.  Note that other instance creators can be written, such as dependency injection instance creators.
+        /// </summary>
+        /// <param name="type">The type.</param>
+        /// <returns>System.Object.</returns>
+        /// <remarks>By default, Activator.CreateInstance will be used to create the instance.  Change the setting InstanceCreator to supply a different instance creator.</remarks>
+        public object CreateInstance(Type type)
+        {
+            object result;
+            if (this.Container.IsRegistered(type))
+            {
+                result = this.Container.Resolve(type);
+            }
+            else
+            {
+                if (this.TranslateConcreteTypes)
+                {
+                    Type interfaceType = this.TranslateToInterface(type);
+                    if (interfaceType != null)
+                    {
+                        result = this.Container.Resolve(interfaceType);
+                    }
+                    else
+                    {
+                       result = this.DefaultInstanceCreator.CreateInstance(type);
+                    }
+                }
+                else
+                {
+                  result = this.DefaultInstanceCreator.CreateInstance(type);
+                }
+            }
+
+            return result;
+        }
+
+        private Type TranslateToInterface(Type concreteType)
+        {
+          Type result = null;
+          var registration = this.Container.ComponentRegistry.Registrations.FirstOrDefault(r => r.Activator.LimitType == concreteType);
+          if (registration != null)
+          {
+            if (registration.Services.Any())
+            {
+              string typeName = registration.Services.Last().Description;
+              foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+              {
+                result = assembly.GetType(typeName);
+                if (result != null)
+                {
+                  break;
+                }
+              }
+            }
+          }
+
+          return result;
+        }
+  }
+}

--- a/SharpSerializer.AutofacInstanceCreator/IAutofacInstanceCreator.cs
+++ b/SharpSerializer.AutofacInstanceCreator/IAutofacInstanceCreator.cs
@@ -1,0 +1,9 @@
+﻿
+namespace SharpSerializer.AutofacInstanceCreator
+{
+    using Polenter.Serialization.Core;
+
+    public interface IAutofacInstanceCreator : IInstanceCreator
+    {
+    }
+}

--- a/SharpSerializer.AutofacInstanceCreator/Properties/AssemblyInfo.cs
+++ b/SharpSerializer.AutofacInstanceCreator/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("SharpSerializer.AutofacInstanceCreator")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("SharpSerializer.AutofacInstanceCreator")]
+[assembly: AssemblyCopyright("Copyright ©  2018")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("9b0de06d-36dc-48ba-b7b6-c5450666c6e7")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/SharpSerializer.AutofacInstanceCreator/SharpSerializer.AutofacInstanceCreator.csproj
+++ b/SharpSerializer.AutofacInstanceCreator/SharpSerializer.AutofacInstanceCreator.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SharpSerializer.AutofacInstanceCreator</RootNamespace>
     <AssemblyName>SharpSerializer.AutofacInstanceCreator</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/SharpSerializer.AutofacInstanceCreator/SharpSerializer.AutofacInstanceCreator.csproj
+++ b/SharpSerializer.AutofacInstanceCreator/SharpSerializer.AutofacInstanceCreator.csproj
@@ -39,6 +39,7 @@
     <Reference Include="System.Drawing" />
     <Reference Include="System.IO.Compression.FileSystem" />
     <Reference Include="System.Numerics" />
+    <Reference Include="System.Runtime.Caching" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/SharpSerializer.AutofacInstanceCreator/SharpSerializer.AutofacInstanceCreator.csproj
+++ b/SharpSerializer.AutofacInstanceCreator/SharpSerializer.AutofacInstanceCreator.csproj
@@ -1,0 +1,64 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{9B0DE06D-36DC-48BA-B7B6-C5450666C6E7}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>SharpSerializer.AutofacInstanceCreator</RootNamespace>
+    <AssemblyName>SharpSerializer.AutofacInstanceCreator</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Autofac, Version=4.6.2.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
+      <HintPath>..\packages\Autofac.4.6.2\lib\net45\Autofac.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.IO.Compression.FileSystem" />
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="AutofacInstanceCreator.cs" />
+    <Compile Include="IAutofacInstanceCreator.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\SharpSerializer\SharpSerializer.csproj">
+      <Project>{d9b06b37-64a0-45c5-a6b7-5af26652c8f0}</Project>
+      <Name>SharpSerializer</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/SharpSerializer.AutofacInstanceCreator/packages.config
+++ b/SharpSerializer.AutofacInstanceCreator/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Autofac" version="4.6.2" targetFramework="net461" />
+</packages>

--- a/SharpSerializer.sln
+++ b/SharpSerializer.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26730.16
+VisualStudioVersion = 15.0.27130.2036
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{FA9C9770-1F72-4C3D-925E-60DFC8599ABD}"
 	ProjectSection(SolutionItems) = preProject
@@ -13,6 +13,10 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SharpSerializer.Tests", "SharpSerializer.Tests\SharpSerializer.Tests.csproj", "{6D44C26F-76A3-48F0-A29A-406603B72695}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SharpSerializer", "SharpSerializer\SharpSerializer.csproj", "{D9B06B37-64A0-45C5-A6B7-5AF26652C8F0}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SharpSerializer.AutofacInstanceCreator", "SharpSerializer.AutofacInstanceCreator\SharpSerializer.AutofacInstanceCreator.csproj", "{9B0DE06D-36DC-48BA-B7B6-C5450666C6E7}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SharpSerializer.AutofacInstanceCreator.Tests", "SharpSerializer.AutofacInstanceCreator.Tests\SharpSerializer.AutofacInstanceCreator.Tests.csproj", "{C480C73C-271A-4127-B13A-AB89942FCDA8}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -32,6 +36,14 @@ Global
 		{D9B06B37-64A0-45C5-A6B7-5AF26652C8F0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D9B06B37-64A0-45C5-A6B7-5AF26652C8F0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D9B06B37-64A0-45C5-A6B7-5AF26652C8F0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9B0DE06D-36DC-48BA-B7B6-C5450666C6E7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9B0DE06D-36DC-48BA-B7B6-C5450666C6E7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9B0DE06D-36DC-48BA-B7B6-C5450666C6E7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9B0DE06D-36DC-48BA-B7B6-C5450666C6E7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C480C73C-271A-4127-B13A-AB89942FCDA8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C480C73C-271A-4127-B13A-AB89942FCDA8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C480C73C-271A-4127-B13A-AB89942FCDA8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C480C73C-271A-4127-B13A-AB89942FCDA8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/SharpSerializer/Advanced/SimpleValueConverter.cs
+++ b/SharpSerializer/Advanced/SimpleValueConverter.cs
@@ -82,6 +82,11 @@ namespace Polenter.Serialization.Advanced
         {
             if (value == null) return string.Empty;
 
+            if (value is DateTime)
+            {
+              return ((DateTime)value).ToString("O");
+            }
+
             // Array of byte
             if (value.GetType() == typeof(byte[]))
             {
@@ -121,7 +126,7 @@ namespace Polenter.Serialization.Advanced
                     return Convert.ToChar(text, _cultureInfo);
                 }
                     
-                if (type == typeof (DateTime)) return Convert.ToDateTime(text, _cultureInfo);
+                if (type == typeof (DateTime)) return DateTime.Parse(text, _cultureInfo, DateTimeStyles.RoundtripKind);
                 if (type == typeof (Decimal)) return Convert.ToDecimal(text, _cultureInfo);
                 if (type == typeof (Double)) return Convert.ToDouble(text, _cultureInfo);
                 if (type == typeof (Int16)) return Convert.ToInt16(text, _cultureInfo);

--- a/SharpSerializer/Core/DefaultInstanceCreator.cs
+++ b/SharpSerializer/Core/DefaultInstanceCreator.cs
@@ -1,0 +1,45 @@
+﻿#region Copyright © 2018 Pawel Idzikowski [idzikowski@sharpserializer.com]
+
+//  ***********************************************************************
+//  Project: sharpSerializer
+//  Web: http://www.sharpserializer.com
+//  
+//  This software is provided 'as-is', without any express or implied warranty.
+//  In no event will the author(s) be held liable for any damages arising from
+//  the use of this software.
+//  
+//  Permission is granted to anyone to use this software for any purpose,
+//  including commercial applications, and to alter it and redistribute it
+//  freely, subject to the following restrictions:
+//  
+//      1. The origin of this software must not be misrepresented; you must not
+//        claim that you wrote the original software. If you use this software
+//        in a product, an acknowledgment in the product documentation would be
+//        appreciated but is not required.
+//  
+//      2. Altered source versions must be plainly marked as such, and must not
+//        be misrepresented as being the original software.
+//  
+//      3. This notice may not be removed or altered from any source distribution.
+//  
+//  ***********************************************************************
+
+#endregion
+
+namespace Polenter.Serialization.Core
+{
+  using System;
+
+  public class DefaultInstanceCreator : IInstanceCreator
+  {
+    /// <summary>
+    /// Creates the instance.
+    /// </summary>
+    /// <param name="type">The type.</param>
+    /// <returns>System.Object.</returns>
+    public object CreateInstance(Type type)
+    {
+      return Tools.CreateInstance(type);
+    }
+  }
+}

--- a/SharpSerializer/Core/IInstanceCreator.cs
+++ b/SharpSerializer/Core/IInstanceCreator.cs
@@ -1,0 +1,44 @@
+﻿#region Copyright © 2018 Pawel Idzikowski [idzikowski@sharpserializer.com]
+
+//  ***********************************************************************
+//  Project: sharpSerializer
+//  Web: http://www.sharpserializer.com
+//  
+//  This software is provided 'as-is', without any express or implied warranty.
+//  In no event will the author(s) be held liable for any damages arising from
+//  the use of this software.
+//  
+//  Permission is granted to anyone to use this software for any purpose,
+//  including commercial applications, and to alter it and redistribute it
+//  freely, subject to the following restrictions:
+//  
+//      1. The origin of this software must not be misrepresented; you must not
+//        claim that you wrote the original software. If you use this software
+//        in a product, an acknowledgment in the product documentation would be
+//        appreciated but is not required.
+//  
+//      2. Altered source versions must be plainly marked as such, and must not
+//        be misrepresented as being the original software.
+//  
+//      3. This notice may not be removed or altered from any source distribution.
+//  
+//  ***********************************************************************
+
+#endregion
+
+
+namespace Polenter.Serialization.Core
+{
+  using System;
+
+  public interface IInstanceCreator
+  {
+    /// <summary>
+    /// Creates an instance of the object of the specific type.  Note that other instance creators can be written, such as dependency injection instance creators.
+    /// </summary>
+    /// <param name="type">The type.</param>
+    /// <returns>System.Object.</returns>
+    /// <remarks>By default, Activator.CreateInstance will be used to create the instance.  Change the setting InstanceCreator to supply a different instance creator.</remarks>
+    object CreateInstance(Type type);
+  }
+}

--- a/SharpSerializer/Core/SharpSerializerSettings.cs
+++ b/SharpSerializer/Core/SharpSerializerSettings.cs
@@ -80,6 +80,12 @@ namespace Polenter.Serialization.Core
         ///   PublicKeyToken=.... will be inserted to the type name
         /// </summary>
         public bool IncludePublicKeyTokenInTypeName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the instance creator that will be used for object creation.  Use this setting to supply a different creator, such as an AutoFac instance creator.
+        /// </summary>
+        /// <value>The instance creator.</value>
+        public IInstanceCreator InstanceCreator { get; set; }
     }
 
     ///<summary>

--- a/SharpSerializer/Deserializing/ObjectFactory.cs
+++ b/SharpSerializer/Deserializing/ObjectFactory.cs
@@ -38,12 +38,30 @@ namespace Polenter.Serialization.Deserializing
     /// </summary>
     public sealed class ObjectFactory
     {
+        public ObjectFactory()
+        : this(new DefaultInstanceCreator())
+        {
+
+        }
+
+        public ObjectFactory(IInstanceCreator instanceCreator)
+        {
+          this.InstanceCreator = instanceCreator;
+        }
+
         private readonly object[] _emptyObjectArray = new object[0];
 
         /// <summary>
         /// Contains already created objects. Is used for reference resolving.
         /// </summary>
         private readonly Dictionary<int, object > _objectCache = new Dictionary<int, object>();
+
+        /// <summary>
+        /// Gets or sets the instance creator.
+        /// </summary>
+        /// <value>The instance creator.</value>
+        private IInstanceCreator InstanceCreator { get; set; }
+
 
         /// <summary>
         ///   Builds object from property
@@ -144,7 +162,7 @@ namespace Polenter.Serialization.Deserializing
 
         private object createObjectFromComplexProperty(ComplexProperty property)
         {
-            object obj = Tools.CreateInstance(property.Type);
+            object obj = this.InstanceCreator.CreateInstance(property.Type);
 
             if (property.Reference != null)
             {
@@ -163,7 +181,7 @@ namespace Polenter.Serialization.Deserializing
         private object createObjectFromCollectionProperty(CollectionProperty property)
         {
             Type type = property.Type;
-            object collection = Tools.CreateInstance(type);
+            object collection = this.InstanceCreator.CreateInstance(type);
 
             if (property.Reference != null)
             {
@@ -200,7 +218,7 @@ namespace Polenter.Serialization.Deserializing
         /// <returns></returns>
         private object createObjectFromDictionaryProperty(DictionaryProperty property)
         {
-            object dictionary = Tools.CreateInstance(property.Type);
+            object dictionary = this.InstanceCreator.CreateInstance(property.Type);
 
             if (property.Reference != null)
             {

--- a/SharpSerializer/Deserializing/ObjectFactory.cs
+++ b/SharpSerializer/Deserializing/ObjectFactory.cs
@@ -264,6 +264,11 @@ namespace Polenter.Serialization.Deserializing
                 PropertyInfo propertyInfo = obj.GetType().GetProperty(property.Name);
                 if (propertyInfo == null) continue;
 
+                if (propertyInfo.CanWrite == false)
+                {
+                  continue;
+                }
+
                 object value = CreateObject(property);
                 if (value == null) continue;
 

--- a/SharpSerializer/SharpSerializer.cs
+++ b/SharpSerializer/SharpSerializer.cs
@@ -136,8 +136,16 @@ namespace Polenter.Serialization
             set { _rootName = value; }
         }
 
+        /// <summary>
+        /// Gets or sets the instance creator for creating objects.
+        /// </summary>
+        /// <value>The instance creator.</value>
+        public IInstanceCreator InstanceCreator { get; set; }
+
         private void initialize(SharpSerializerXmlSettings settings)
         {
+            this.InstanceCreator = settings.InstanceCreator ?? new DefaultInstanceCreator();
+
             // PropertiesToIgnore
             PropertyProvider.PropertiesToIgnore = settings.AdvancedSettings.PropertiesToIgnore;
             PropertyProvider.AttributesToIgnore = settings.AdvancedSettings.AttributesToIgnore;
@@ -167,6 +175,8 @@ namespace Polenter.Serialization
 
         private void initialize(SharpSerializerBinarySettings settings)
         {
+            this.InstanceCreator = settings.InstanceCreator ?? new DefaultInstanceCreator();
+
             // PropertiesToIgnore
             PropertyProvider.PropertiesToIgnore = settings.AdvancedSettings.PropertiesToIgnore;
             PropertyProvider.AttributesToIgnore = settings.AdvancedSettings.AttributesToIgnore;
@@ -292,7 +302,7 @@ namespace Polenter.Serialization
                     _deserializer.Close();
 
                     // create object from Property
-                    var factory = new ObjectFactory();
+                    var factory = new ObjectFactory(this.InstanceCreator);
                     return factory.CreateObject(property);
                 }
                 catch (Exception exception)


### PR DESCRIPTION
Previously, objectfactory only used Activator.CreateInstance (in the Tools helper class) to create objects.  However, sometimes objects need to be created with dependencies injected.

I added the ability for sharpserializer to do that, and also provided an autofac implementation, in a separate project, which could be put into it's own nuget package.

Thanks for sharp serializer.  It works great.